### PR TITLE
Fix encoding from iso8859-1 to utf8

### DIFF
--- a/DCC_Zubehoerdecoder/src/DebugDefs.h
+++ b/DCC_Zubehoerdecoder/src/DebugDefs.h
@@ -1,4 +1,4 @@
-// Definitionen für Debugging über die serielle Schnittstell
+// Definitionen fÃ¼r Debugging Ã¼ber die serielle Schnittstell
 
 #ifndef DEBUGDEFS
 #define DEBUGDEFS

--- a/DCC_Zubehoerdecoder/src/FuncClasses.cpp
+++ b/DCC_Zubehoerdecoder/src/FuncClasses.cpp
@@ -1,15 +1,15 @@
-/* DIY Zubehördecoder
+/* DIY ZubehÃ¶rdecoder
  *
- * Klassen für die einzelnen Funktionen FSERVO, FCOIL, FSIGNAL, FSTATIC
- * Für jede im Konfig-File definierte Funktion muss ein passendes Objekt instanziiert werden.
+ * Klassen fÃ¼r die einzelnen Funktionen FSERVO, FCOIL, FSIGNAL, FSTATIC
+ * FÃ¼r jede im Konfig-File definierte Funktion muss ein passendes Objekt instanziiert werden.
  * Die Instanziierung muss im setup() mit 'new' erfolgen.
  * Jeder Klasse muss bei der Instanziierung die Basis CV-Adresse des Blocks mit den Konfigurationswerten
- * übergeben werden, sowie ein Array mit den Pin-Nummern der Ausgangsports.
- * Bei Lichtsignalen zusätzlich die Zahl der Ausgangspins (max 8) und ein Pointer auf den Objektpointer 
+ * Ã¼bergeben werden, sowie ein Array mit den Pin-Nummern der Ausgangsports.
+ * Bei Lichtsignalen zusÃ¤tzlich die Zahl der Ausgangspins (max 8) und ein Pointer auf den Objektpointer 
  * des Vorsignals am gleichen Mast (oder NULL, wenn kein Vorsignal am Mast vorhanden ist, oder es sich 
  * schon um ein Vorsignal handelt )
- * Alle Klassen haben mindestens 2 öffentliche Methoden:
- * 'process' bearbeitet interne Abläufe und muss im loop regelmäßig aufgerufen werden
+ * Alle Klassen haben mindestens 2 Ã¶ffentliche Methoden:
+ * 'process' bearbeitet interne AblÃ¤ufe und muss im loop regelmÃ¤ÃŸig aufgerufen werden
  * 'set'     gibt einen Schaltbefehl an das Objekt ( z.B. Weiche links/rechts )
  * weitere Methoden sind klassenspezifisch.
  */
@@ -40,7 +40,7 @@ void _digitalWrite( byte port, byte state ) {
 // Ansteuerung von Doppelspulenantrieben
 
 Fcoil::Fcoil( int cvAdr, uint8_t out1P[] ) {
-    // Konstruktor für Doppelspulenantriebe
+    // Konstruktor fÃ¼r Doppelspulenantriebe
     _cvAdr = cvAdr;
     _outP = out1P;
     DB_PRINT( "Fcoil CV=%d, OutPins %d,%d ", _cvAdr, _outP[0], _outP[1] );
@@ -65,9 +65,9 @@ void Fcoil::set( uint8_t dccSoll, uint8_t dccState ) {
 
 //..............    
 void Fcoil::process() {
-        // Pulseausgägne einschalten
+        // PulseausgÃ¤gne einschalten
     if (  !_flags.pulseON && !_pulseT.running() &&  _flags.sollAct ) {
-        // Aktionen am Ausgang nur wenn kein aktiver Impuls und der Pausentimer nicht läuft
+        // Aktionen am Ausgang nur wenn kein aktiver Impuls und der Pausentimer nicht lÃ¤uft
         DB_PRINT(" Ist=%d, Soll=%d ", _flags.istCoil, _flags.sollCoil );
         if ( ( _flags.istCoil != _flags.sollCoil || (getParam( MODE) & NOPOSCHK) )
                 && _flags.sollOut ) {
@@ -92,13 +92,13 @@ void Fcoil::process() {
         _flags.sollAct = false; // Sollwert wurde bearbeitet.
     }
     
-    // Pulsausgänge ausschalten
+    // PulsausgÃ¤nge ausschalten
     if ( _flags.pulseON ) {
-        // prüfen ab Impuls abgeschaltet werden muss
+        // prÃ¼fen ab Impuls abgeschaltet werden muss
         if ( !(getParam( MODE) & CAUTOOFF) && _flags.sollAct && ! _flags.sollOut ) {
             // ein Abschalttelegramm wurde empfangen
             _flags.pulseON = false;
-            _pulseT.setTime( 0 );     // Timer abschalten, falls er läuft
+            _pulseT.setTime( 0 );     // Timer abschalten, falls er lÃ¤uft
             _flags.sollAct = false;  // Empfangenes Telegramm wurde bearbeitet.
         }
         // Timerabschaltung
@@ -111,7 +111,7 @@ void Fcoil::process() {
         if ( _flags.pulseON == false ) {
             digitalWrite( _outP[0], LOW );
             digitalWrite( _outP[1], LOW );
-            // Timer für Pulspause setzen
+            // Timer fÃ¼r Pulspause setzen
             if ( getParam( PAR2) > 0 ) _pulseT.setTime( getParam( PAR2) * 10 );
         }
         
@@ -124,7 +124,7 @@ void Fcoil::process() {
 // Ansteuerung von statischen/blinkenden Leds
 
 Fstatic::Fstatic( int cvAdr, uint8_t ledP[] ) {
-    // Konstruktor der Klasse für statisches Leuchten bzw. blinken
+    // Konstruktor der Klasse fÃ¼r statisches Leuchten bzw. blinken
     _cvAdr = cvAdr;
     _ledP = ledP;
     DB_PRINT( "Fstatic CV=%d, LedPis %d,%d ", _cvAdr, _ledP[0], _ledP[1] );
@@ -154,7 +154,7 @@ Fstatic::Fstatic( int cvAdr, uint8_t ledP[] ) {
     set( getParam( STATE ) );
     /*
     if ( getParam( MODE ) & BLKMODE ) {
-        // aktuellen Blinkstatus berücksichtigen
+        // aktuellen Blinkstatus berÃ¼cksichtigen
         _setLedPin(0, LOW );
         _setLedPin(1, LOW );
     } else {
@@ -261,23 +261,23 @@ void Fservo::process() {
     // Diese Methode muss in jedem loop() Durchlauf aufgerufen werden
 
     if ( _flags.moving ) {
-        // Weiche wird gerade ungestellt, Schaltpunkt Relais und Bewegungsende überwachen
+        // Weiche wird gerade ungestellt, Schaltpunkt Relais und Bewegungsende Ã¼berwachen
         if ( _flags.sollAbzw != _flags.isAbzw && (getParam( MODE) & SDIRECT) ) {
             // Es wurde die Servoposition umgeschalten und das Flag SDIRECT ist
-            // gesetzt: Bewegung abbrechen und Moving-Bit löschen.
-            // Im nächsten loop-Durchlauf wird dann auf die neue Position reagiert
+            // gesetzt: Bewegung abbrechen und Moving-Bit lÃ¶schen.
+            // Im nÃ¤chsten loop-Durchlauf wird dann auf die neue Position reagiert
             _weicheS.write( _weicheS.read() );
             _flags.moving = false;; 
         }
         if ( _weicheS.moving() < 50 ) _flags.relOn = _flags.isAbzw;
         if ( _weicheS.moving() == 0 ) {
-            // Bewegung abgeschlossen, 'MOVING'-Bit löschen und Lage in CV speichern
+            // Bewegung abgeschlossen, 'MOVING'-Bit lÃ¶schen und Lage in CV speichern
             _flags.moving = false; 
             _flags.sollAct = false;
             setState( _flags.isAbzw );
             /*if ( getParam( MODE ) & NOPOSCHK ) {
-                // Soll auf 'ungültig' stellen, damit auch neue Telegramme mit gleicher
-                // Position erkannt werden (ausser es wurde schon verändert )
+                // Soll auf 'ungÃ¼ltig' stellen, damit auch neue Telegramme mit gleicher
+                // Position erkannt werden (ausser es wurde schon verÃ¤ndert )
                 if ( _flags.sollAbzw == _fktStatus ) _flags.sollAbzw = SOLL_INVALID;
                 DB_PRINT( "dccSoll=%d", _flags.sollAbzw );
             }*/
@@ -293,12 +293,12 @@ void Fservo::process() {
             _weicheS.write( getParam( PAR1) );
         }
     }
-    // Relaisausgänge setzen
+    // RelaisausgÃ¤nge setzen
     if ( _outP[REL2P] == NC ) {
         // Variante mit einem Relais, wird in Bewegungsmitte umgeschaltet
         _digitalWrite( _outP[REL1P], _flags.relOn );
     } else {
-        // Variante mit 2 Relais, während der Bewegung beide Relais abschalten
+        // Variante mit 2 Relais, wÃ¤hrend der Bewegung beide Relais abschalten
         if ( _flags.moving ) {
             _digitalWrite( _outP[REL1P], OFF );
             _digitalWrite( _outP[REL2P], OFF );
@@ -323,7 +323,7 @@ uint8_t Fservo::getPos(){
 }
 //..............    
 void Fservo::adjust( uint8_t mode, uint8_t value ) {
-    // Servoparameter ändern
+    // Servoparameter Ã¤ndern
     DB_PRINT( "adjust: mode=%d, val=%d", mode, value );
     switch ( mode ) {
       case ADJPOSEND:
@@ -344,7 +344,7 @@ void Fservo::adjust( uint8_t mode, uint8_t value ) {
 void Fservo::center( uint8_t mode ){ 
     // Servo auf Mittelstellung bringen
     if ( mode == ABSOLUT) {
-        // absolute Mittelstellung (90°)
+        // absolute Mittelstellung (90Â°)
         _weicheS.write(90);
     } else if ( mode == RELATIVE ) {
         _weicheS.write( getParam( PAR1)/2 + getParam( PAR2)/2 );
@@ -357,7 +357,7 @@ void Fservo::center( uint8_t mode ){
 // Ansteuerung von Lichtsignalen
 
 Fsignal::Fsignal( int cvAdr, uint8_t pins[], uint8_t pinAnz, Fsignal** vorSig ){
-    // Konstruktor für den Signaldecoder mit 1 bis 3 Adressen
+    // Konstruktor fÃ¼r den Signaldecoder mit 1 bis 3 Adressen
     // Signale werden immer mit dem Grundzustand initiiert ( = HP0 oder Hp00 )
     
     _cvAdr  = cvAdr;
@@ -366,19 +366,19 @@ Fsignal::Fsignal( int cvAdr, uint8_t pins[], uint8_t pinAnz, Fsignal** vorSig ){
     // Zahl der zugeordneten Ausgangsports (maximal 8 genutzt)
     _outP = pins;
     _sigLed = new SoftLed*[_pinAnz] ;
-    _fktStatus.sigBild=0x7; // ungültiges Signalbild
+    _fktStatus.sigBild=0x7; // ungÃ¼ltiges Signalbild
     _fktStatus.state = SIG_WAIT;
     _fktStatus.dark = false;
      
     DB_PRINT( "Fsignal CV=%d, Pins %d", _cvAdr, _pinAnz);
-    //Modi der Ausgänge setzen ( 3 Ausgänge je Adresse ) (Soft/Hard)
+    //Modi der AusgÃ¤nge setzen ( 3 AusgÃ¤nge je Adresse ) (Soft/Hard)
     for ( byte pIx=0; pIx < _pinAnz ; pIx++ ) {
-        // Modi der Ausgänge setzen
+        // Modi der AusgÃ¤nge setzen
         byte sigMode = _getHsMask(); // Bitcodierung harte/weiche Ledumschaltung
 		_sigLed[pIx] = NULL;		 // Softled-Pointer mit NULL initiieren
         if ( _outP[pIx] != NC ) {
-            // Die CV_s verwalten die pins Adressbezogen ( 1 CV für 3 Pins )
-            // sigMode enthält bitcodiert die Info ob harte/weiche Umschaltung
+            // Die CV_s verwalten die pins Adressbezogen ( 1 CV fÃ¼r 3 Pins )
+            // sigMode enthÃ¤lt bitcodiert die Info ob harte/weiche Umschaltung
            //DB_PRINT( "SigMode=%02x, Index= %d, pin=%d, ", sigMode, sigO,outPin);
             if ( sigMode & (1<<pIx) ) {
                 // Bit gesetzt -> harte Umschaltung
@@ -386,7 +386,7 @@ Fsignal::Fsignal( int cvAdr, uint8_t pins[], uint8_t pinAnz, Fsignal** vorSig ){
                 _sigLed[pIx] = NULL;
             } else {
                 // Bit = 0 -> Softled
-                byte att, rise, writ; // nur für Testzwecke ( DB_PRINT )
+                byte att, rise, writ; // nur fÃ¼r Testzwecke ( DB_PRINT )
                 _sigLed[pIx] = new SoftLed;
                 att=_sigLed[pIx]->attach( _outP[pIx] , getParam( LSMODE ) & LEDINVERT );
                 _sigLed[pIx]->riseTime( SIG_RISETIME );
@@ -402,8 +402,8 @@ Fsignal::Fsignal( int cvAdr, uint8_t pins[], uint8_t pinAnz, Fsignal** vorSig ){
 }
 
 
-//----- öffentliche Methoden -----------------------------------------------------------
-// Signal dunkelschalten ( genutzt für Vorsignale am Mast eines Hauptsignals )
+//----- Ã¶ffentliche Methoden -----------------------------------------------------------
+// Signal dunkelschalten ( genutzt fÃ¼r Vorsignale am Mast eines Hauptsignals )
 void Fsignal::setDark( bool darkFlg ) {
     // Ist das Flag 'true' wird das Signal dunkelgeschaltet
     if ( darkFlg ) {
@@ -424,12 +424,12 @@ void Fsignal::setDark( bool darkFlg ) {
 void Fsignal::set( uint8_t sollWert ) {
     DB_PRINT( "setSignal, CV%d, Soll=%d, Ist=%d", _cvAdr, sollWert,  _fktStatus.sigBild )
     if (  _fktStatus.sigBild != sollWert ) {
-        // Sollzustand hat sich verändert, püfen ob erlaubter Zustand
+        // Sollzustand hat sich verÃ¤ndert, pÃ¼fen ob erlaubter Zustand
         if (  _getSigMask( sollWert) == 0xff )  {
             // Sollzustand hat Signalmaske 0xff -> diesen Zustand ignorieren
-            // Sollzustand zurücksetzen
+            // Sollzustand zurÃ¼cksetzen
         } else {
-            // Gültiger Zustand, übernehmen, Flag setzen und Timer aufziehen
+            // GÃ¼ltiger Zustand, Ã¼bernehmen, Flag setzen und Timer aufziehen
             _fktStatus.sigBild =  sollWert;
             _fktStatus.state   = SIG_NEW;
             darkT.setTime( SIG_DARK_TIME ) ;
@@ -445,7 +445,7 @@ void Fsignal::process() {
  
     switch ( _fktStatus.state ) {
       case SIG_WAIT:  
-        // warten auf Zustandsänderung am Signal
+        // warten auf ZustandsÃ¤nderung am Signal
         // wurde 'set' aufgerufen, und das Signalbild muss umgeschaltet werden, so 
         // wird die Statemachine in der 'set' Methode weitergeschaltet
         break;
@@ -470,10 +470,10 @@ void Fsignal::process() {
 }
 
 //-------------- private Methoden -----------------------------------------------
-// Maske Hard/Soft für alle Pins bestimmen 
+// Maske Hard/Soft fÃ¼r alle Pins bestimmen 
 uint8_t Fsignal::_getHsMask(){
     // die Bits stehen jeweils in 3er Gruppen bei den Parametern je Adresse
-    // Maximal können 8 Ausgänge verwaltet werden
+    // Maximal kÃ¶nnen 8 AusgÃ¤nge verwaltet werden
     uint8_t hsMask = getParam( LSMODE ) & 0x7;
     if ( _pinAnz > PPWA ) hsMask |= (getParam( SOFTMASK2 ) & 0x7) << 3; 
     if ( _pinAnz > 2*PPWA ) hsMask |= (getParam( SOFTMASK3 ) & 0x3) << 6;     
@@ -481,7 +481,7 @@ uint8_t Fsignal::_getHsMask(){
 }
 
 //..............    
-// Ausgangsmaske für Signalbild sigState bestimmen
+// Ausgangsmaske fÃ¼r Signalbild sigState bestimmen
 uint8_t  Fsignal::_getSigMask( uint8_t sigState ) {
     // sState: Signalzustand
     static int parOffs[] = { 1,2,6,7,11,12,16,17 } ; // max 4 Adressen vorgesehen
@@ -490,27 +490,27 @@ uint8_t  Fsignal::_getSigMask( uint8_t sigState ) {
 }
 
 //..............    
-// alle Signalausgänge entsprechend dem derzeitigen Signalzustand setzen
+// alle SignalausgÃ¤nge entsprechend dem derzeitigen Signalzustand setzen
 void Fsignal::_setSignal ( ) {
-    //byte sigZustand; // aktueller Signalzustand, abgeleitet aus den Weichenzuständen
-    byte sigOutMsk;  // Bitmaske der Ausgangsports (Bit=1:Ausgang setzen, Bit=0 Ausgang rücksetzen
-                     // Diese Maske steht für jeden Signalzustand in entsprechenden CV-Paramtern:
-                     // CV51+offs    Bitmuster der Ausgänge für Befehl 1.Adresse 0 (rot)
-                     // CV52+offs    Bitmuster der Ausgänge für Befehl 1.Adresse 1 (grün)
-                     // CV56+offs    Bitmuster der Ausgänge für Befehl 2.Adresse 0 (rot)
-                     // CV57+offs    Bitmuster der Ausgänge für Befehl 2.Adresse 1 (grün)
-                     // die folgenden CV's sind nur relevant bei FSIGNAL3 (3 Adressen, 8 Zustände 6 Ausgänge)
-                     // CV61+offs    Bitmuster der Ausgänge für Befehl 3.Adresse 0 (rot)
-                     // CV62+offs    Bitmuster der Ausgänge für Befehl 3.Adresse 1 (grün)
+    //byte sigZustand; // aktueller Signalzustand, abgeleitet aus den WeichenzustÃ¤nden
+    byte sigOutMsk;  // Bitmaske der Ausgangsports (Bit=1:Ausgang setzen, Bit=0 Ausgang rÃ¼cksetzen
+                     // Diese Maske steht fÃ¼r jeden Signalzustand in entsprechenden CV-Paramtern:
+                     // CV51+offs    Bitmuster der AusgÃ¤nge fÃ¼r Befehl 1.Adresse 0 (rot)
+                     // CV52+offs    Bitmuster der AusgÃ¤nge fÃ¼r Befehl 1.Adresse 1 (grÃ¼n)
+                     // CV56+offs    Bitmuster der AusgÃ¤nge fÃ¼r Befehl 2.Adresse 0 (rot)
+                     // CV57+offs    Bitmuster der AusgÃ¤nge fÃ¼r Befehl 2.Adresse 1 (grÃ¼n)
+                     // die folgenden CV's sind nur relevant bei FSIGNAL3 (3 Adressen, 8 ZustÃ¤nde 6 AusgÃ¤nge)
+                     // CV61+offs    Bitmuster der AusgÃ¤nge fÃ¼r Befehl 3.Adresse 0 (rot)
+                     // CV62+offs    Bitmuster der AusgÃ¤nge fÃ¼r Befehl 3.Adresse 1 (grÃ¼n)
                      // offs= wIx*5
                      //
     if ( !_fktStatus.dark ) {
         // Signal ist nicht dunkelgeschaltet, Signalbild aufblenden
         DB_PRINT( "Sig %d EIN (%d)", _cvAdr, _fktStatus.sigBild );
         // das aktuelle Signalbild steht in _fktStatus.sigBild
-        // Ausgangszustände entsprechend Signalzustand bestimmen (CV-Wert)
+        // AusgangszustÃ¤nde entsprechend Signalzustand bestimmen (CV-Wert)
         sigOutMsk = _getSigMask( _fktStatus.sigBild ) ;
-        // Die Ausgänge entsprechend dem aktuellen Signalbild setzen
+        // Die AusgÃ¤nge entsprechend dem aktuellen Signalbild setzen
         for ( byte i=0; i< _pinAnz ; i++ ) {
             if ( _sigLed[i] == NULL ) {
                 // Standard-Ausgang
@@ -521,16 +521,16 @@ void Fsignal::_setSignal ( ) {
             }
             sigOutMsk = sigOutMsk >> 1;
         }
-        //DB_PRINT( " Signal %d, Status=0x%02x, Ausgänge: 0x%02x ", wIx, sigZustand, Dcc.getCV( CVBaseAdr[sigZustand] + CVoffs)  );
+        //DB_PRINT( " Signal %d, Status=0x%02x, AusgÃ¤nge: 0x%02x ", wIx, sigZustand, Dcc.getCV( CVBaseAdr[sigZustand] + CVoffs)  );
     }
 }
  
 //..............    
-// alle Signallampen ausschalten ( beim Überblenden zwischen Signalbildern )
+// alle Signallampen ausschalten ( beim Ãœberblenden zwischen Signalbildern )
 void Fsignal::_clrSignal () {
     // alle 'Soft'Leds des Signals ausschalten
     DB_PRINT( "Sig %d AUS", _cvAdr);
-    // nur 'soft' Ausgangszustände löschen
+    // nur 'soft' AusgangszustÃ¤nde lÃ¶schen
     for ( byte pIx=0; pIx< _pinAnz ; pIx++ ) {
         if ( _sigLed[pIx] != NULL ) _sigLed[pIx]->write( OFF, BULB ); 
     }

--- a/DCC_Zubehoerdecoder/src/FuncClasses.h
+++ b/DCC_Zubehoerdecoder/src/FuncClasses.h
@@ -1,11 +1,11 @@
-/* DIY Zubehördecoder
+/* DIY ZubehÃ¶rdecoder
  *
- * Klassen für die einzelnen Funktionen FSERVO, FCOIL, FSIGNAL, FSTATIC
- * Für jede im Konfig-File definierte Funktion muss ein passendes Objekt instanziiert werden.
+ * Klassen fÃ¼r die einzelnen Funktionen FSERVO, FCOIL, FSIGNAL, FSTATIC
+ * FÃ¼r jede im Konfig-File definierte Funktion muss ein passendes Objekt instanziiert werden.
  * Die Instanziierung muss im setup() mit 'new' erfolgen.
  */
 #include <MobaTools.h>
-#include "../interface.h"
+#include "../Interface.h"
 
 #define PPWA 3                  // Zahl der Pins je Weichenadresse
 
@@ -21,8 +21,8 @@ const byte MODE=0, PAR1=1, PAR2=2, PAR3=3, STATE=4 ;
     #define setParam( parAdr, value ) ifc_setCV( _cvAdr+parAdr, value )
     #define setState( value )  ifc_setCV( _cvAdr+STATE, value )
 #else
-    // Zugriff auf die Konfig-Parameter direkt über EEPROM:
-    // ( nicht möglich bei LocoNet Interface )
+    // Zugriff auf die Konfig-Parameter direkt Ã¼ber EEPROM:
+    // ( nicht mÃ¶glich bei LocoNet Interface )
     #include <EEPROM.h>
     #define getParam( parAdr ) EEPROM.read( _cvAdr+parAdr )
     #define setParam( parAdr, value ) EEPROM.update( _cvAdr+parAdr, value )
@@ -42,10 +42,10 @@ void _digitalWrite( byte port, byte state ) ;
 //========================= Funktionsklassen  =========================================
 
 //---------------------- FCOIL -------------------------------------------
-// Flags für CV 'MODE'
+// Flags fÃ¼r CV 'MODE'
 #define CAUTOOFF 0x01   // Die Impulsdauer wird intern begrenzt
-#define NOPOSCHK 0x08   // Die Ausgänge reagieren auch auf einen Befehl, wenn die aktuelle
-                        // Postion nicht verändert wird.
+#define NOPOSCHK 0x08   // Die AusgÃ¤nge reagieren auch auf einen Befehl, wenn die aktuelle
+                        // Postion nicht verÃ¤ndert wird.
  
  class Fcoil {
      public:
@@ -57,10 +57,10 @@ void _digitalWrite( byte port, byte state ) ;
     private:
     EggTimer _pulseT;
     struct {
-        bool pulseON   :1 ;            // Flag ob Pausentimer läuft
+        bool pulseON   :1 ;            // Flag ob Pausentimer lÃ¤uft
         bool sollOut   :1;
         bool sollCoil  :1;       // anzusteuernde Spule
-        bool sollAct   :1;       // Sollwert wurde noch nicht übernommen
+        bool sollAct   :1;       // Sollwert wurde noch nicht Ã¼bernommen
         bool istCoil   :1;
     }_flags;
     #define GERADE  0x0             // Bit 0
@@ -72,10 +72,10 @@ void _digitalWrite( byte port, byte state ) ;
  };
 
 //------------------------FSTATIC -------------------------------------------- 
-// Flags für CV 'MODE':
-#define BLKMODE 0x01    // Ausgänge blinken
-#define BLKSTRT 0x02    // Starten mit beide Ausgängen EIN
-#define BLKSOFT 0x04    // Ausgänge als Softleds
+// Flags fÃ¼r CV 'MODE':
+#define BLKMODE 0x01    // AusgÃ¤nge blinken
+#define BLKSTRT 0x02    // Starten mit beide AusgÃ¤ngen EIN
+#define BLKSOFT 0x04    // AusgÃ¤nge als Softleds
 
 
  class Fstatic {
@@ -100,11 +100,11 @@ void _digitalWrite( byte port, byte state ) ;
  };
 
 //------------------------ FSERVO -------------------------------------------- 
-// Flags für CV 'MODE'
+// Flags fÃ¼r CV 'MODE'
 #define SAUTOOFF 0x01   // Impulse werden nach erreichen der Endlage abgeschaltet
-#define SDIRECT  0x02   // FDer Servo reagiert auch während der Bewegung auf einen Umschaltbefehl
-#define NOPOSCHK 0x08   // Die Ausgänge reagieren auch auf einen Befehl, wenn die aktuelle
-                        // Postion nicht verändert wird.
+#define SDIRECT  0x02   // FDer Servo reagiert auch wÃ¤hrend der Bewegung auf einen Umschaltbefehl
+#define NOPOSCHK 0x08   // Die AusgÃ¤nge reagieren auch auf einen Befehl, wenn die aktuelle
+                        // Postion nicht verÃ¤ndert wird.
 class Fservo {
     public:
     Fservo( int cvAdr, uint8_t pins[] );
@@ -112,34 +112,34 @@ class Fservo {
     void set( bool sollWert );       // neuen Schaltbefehl erhalten
 	bool isMoving ();					// Abfrage ob Servo in Bewegung
 	uint8_t getPos();					// aktuellen Status der Weiche ermitteln (GERADE/ABZW)
-	void adjust( uint8_t mode, uint8_t value );	// Servoparamter ändern
-		#define ADJPOS		0			// für Endagenjustierung: value = neue Position
-		#define ADJPOSEND	1			// neue Endlage in CV übernehmen
-		#define ADJSPEED	2			// Servogeschwindigkeit ändern
+	void adjust( uint8_t mode, uint8_t value );	// Servoparamter Ã¤ndern
+		#define ADJPOS		0			// fÃ¼r Endagenjustierung: value = neue Position
+		#define ADJPOSEND	1			// neue Endlage in CV Ã¼bernehmen
+		#define ADJSPEED	2			// Servogeschwindigkeit Ã¤ndern
     void center( uint8_t mode );
-		#define ABSOLUT	 0 		// Servo auf 90° stellen
+		#define ABSOLUT	 0 		// Servo auf 90Â° stellen
 		#define RELATIVE 1		// Mittelstellung zwischen den programmierten Endpunkten
         
     private:
     Servo8  _weicheS;
     uint16_t _cvAdr = 0;            // Adresse des CV-Blocks mit den Funktionsparametern
-    uint8_t *_outP;           		// Array mit Pins der Ausgänge
+    uint8_t *_outP;           		// Array mit Pins der AusgÃ¤nge
 		#define SERVOP	0
 		#define REL1P	1
 		#define REL2P	2
     struct {
         bool relOn    :1 ;           // Ausgangszustand der Relais  
         bool moving   :1 ;           // Servo in Bewegung
-        bool sollAbzw :1 ;           // Vorgabe für neue Servostellung
-        bool sollAct  :1 ;           // Sollwert wurde noch nicht übernommen
+        bool sollAbzw :1 ;           // Vorgabe fÃ¼r neue Servostellung
+        bool sollAct  :1 ;           // Sollwert wurde noch nicht Ã¼bernommen
         bool isAbzw   :1 ;           // Servo steht auf 'Abweig'
     } _flags;
  
  };
 //------------------------ FSIGNAL -------------------------------------------- 
-//Konstante für Lichtsignalfunktion
-// Flags für CV MODE:
-#define LEDINVERT 0x80  // FSIGNAL: SoftledAusgänge invertieren (Bit 7 des Modebyte von FSIGNAL2/3)
+//Konstante fÃ¼r Lichtsignalfunktion
+// Flags fÃ¼r CV MODE:
+#define LEDINVERT 0x80  // FSIGNAL: SoftledAusgÃ¤nge invertieren (Bit 7 des Modebyte von FSIGNAL2/3)
 const byte  LSMODE=0,       BILD1=1,    BILD2=2, VORSIG=3, DARKMASK = 4, 
             SOFTMASK2 = 5,  BILD3=6,    BILD4=7,
             SOFTMASK3=10,   BILD5=11,   BILD6=12;
@@ -151,21 +151,21 @@ const byte  LSMODE=0,       BILD1=1,    BILD2=2, VORSIG=3, DARKMASK = 4,
     Fsignal( int cvAdr, uint8_t pins[], uint8_t adrAnz, Fsignal** vorSig );
 		// adrAnz ist die Zahl der Adressen, die das Signal belegt. Daraus ergibt sich
 		// auch die Zahl der CV-Parameter und die Zahl der Pins
-    void process();                    // muss im loop() regelmäßig aufgerufen werden
+    void process();                    // muss im loop() regelmÃ¤ÃŸig aufgerufen werden
     void set( uint8_t sollWert );      // neuen Signalbefehl erhalten
     void setDark  ( bool darkFlg );    // 'true' schaltet das Signal aus(dunkel), 'false' ein
     
     private:
     void    _clrSignal ();             // SoftLed's ausschalten
     void    _setSignal ();             // aktuelles Signalbild einschalten
-    uint8_t _getHsMask ();             // Maske für Hard/Soft Umschaltung aller Ausgänge bestimmen
-    uint8_t _getSigMask( uint8_t ) ;   // Bitmaske der Ausgänge für aktuelles Signalbild bestimmen
+    uint8_t _getHsMask ();             // Maske fÃ¼r Hard/Soft Umschaltung aller AusgÃ¤nge bestimmen
+    uint8_t _getSigMask( uint8_t ) ;   // Bitmaske der AusgÃ¤nge fÃ¼r aktuelles Signalbild bestimmen
     
     Fsignal **_vorSig;              // Pointer auf Vorsignal am gleichen Mast
-    EggTimer darkT;                 // Dunkelzeit beim Überblenden zwischen Signalbildern
+    EggTimer darkT;                 // Dunkelzeit beim Ãœberblenden zwischen Signalbildern
     uint16_t _cvAdr = 0;            // Adresse des CV-Blocks mit den Funktionsparametern
     uint8_t  _pinAnz;               // Zahl der zugeordnten Ausgangspins : 3(PPWA) je CV-Block 
-    uint8_t *_outP;           		// Array mit Pins der Ausgänge
+    uint8_t *_outP;           		// Array mit Pins der AusgÃ¤nge
     SoftLed **_sigLed;              // Pointer auf Array der Softled Objekte
     struct {
         byte state   :2;            // Status der internen State-Machine

--- a/DCC_Zubehoerdecoder/src/Interface.cpp
+++ b/DCC_Zubehoerdecoder/src/Interface.cpp
@@ -1,6 +1,6 @@
-/* Interface des Zubehördecoders
-** Alle Interface-abhängigen ( Loconet oder DCC ) Programmkomponenten werden hier
-** zusammengefasst, und neutrale Aufrufe für die Funktionalitäten im Sketch zur Verfügung gestellt.
+/* Interface des ZubehÃ¶rdecoders
+** Alle Interface-abhÃ¤ngigen ( Loconet oder DCC ) Programmkomponenten werden hier
+** zusammengefasst, und neutrale Aufrufe fÃ¼r die FunktionalitÃ¤ten im Sketch zur VerfÃ¼gung gestellt.
 */
 #include "../Interface.h"
 #include "DebugDefs.h"
@@ -103,7 +103,7 @@ void notifySVChanged(uint16_t Offset){
 }
 
 #else
-#error "Der Zubehördecoder mit LocoNet Interface läuft nicht auf dieser Platform"
+#error "Der ZubehÃ¶rdecoder mit LocoNet Interface lÃ¤uft nicht auf dieser Platform"
 #endif
 
 #else
@@ -151,7 +151,7 @@ uint16_t ifc_getAddr(){
     #if defined(NMRADCC_VERSION) && NMRADCC_VERSION >= 200
     return Dcc.getAddr(); 
     #else 
-    // wegen Fehler in älteren Versionen der Lib bei Adressen>255, die Adresse selbst berechenen
+    // wegen Fehler in Ã¤lteren Versionen der Lib bei Adressen>255, die Adresse selbst berechenen
     uint8_t CV29Value = Dcc.getCV( CV_29_CONFIG ) ; 
 
     if( CV29Value & CV29_OUTPUT_ADDRESS_MODE ) 


### PR DESCRIPTION
Das Encoding der Dateien ist nicht in allen c++ Files gleich. Ich habe es auf UTF-8 geändert.

Unter Linux kann src/FuncClasses.h nicht kompiliert werden, da unter Linux #include "../interface.h" fehl schlägt. Linux unterscheidet zwischen Groß- und Kleinschreibung.